### PR TITLE
 Remove item that represents a bad practice

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,6 @@
         <li>Is a team player that goes to the same meetings their co-workers are required to go to.</li>
         <li>Reads the Docs.</li>
         <li>Updates the Docs.</li>
-        <li>Pushes to production on a Friday.</li>
         <li>Doesn't need to be passionate about the code they write or the problems they solve, but may be.</li>
         <li>Are willing and able to collaborate with others.</li>
         <li>Willing to admit when they're wrong, and aren't afraid to say "I don't know."</li>


### PR DESCRIPTION
Pushing to production on a Friday is potentially risky for the health of the project, can inconvenience customers, and can be considered disrespectful to the other engineers who may be called to fix things over the weekend. It doesn’t seem to belong in this list of otherwise positive, constructive qualities.