### PR TITLE
Add the missing space to "Stack Overflow"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
               <li>Is willing and able to collaborate with others.</li>
               <li>Willing to admit when they're wrong, and aren't afraid to say "I don't know."</li>
               <li>Will help up-level others.</li>
-              <li>Copy/pastes code snippets from StackOverflow.</li>
+              <li>Copy/pastes code snippets from Stack Overflow.</li>
               <li>Asks questions.</li>
               <li>May or may not like writing documentation, but does it anyway for future maintainers.</li>
               <li>Can be thankful for others' time, effort, and energy.</li>


### PR DESCRIPTION
At least on the site, it’s always spelt as two words, not one.