### PR TITLE
Remove double entry from bad merge

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,6 @@
               <li>Reads the Docs.</li>
               <li>Updates the Docs.</li>
               <li>Doesn't need to be passionate about the code they write or the problems they solve, but may be.</li>
-              <li>Are willing and able to collaborate with others.</li>
               <li>Doesn't act surprised when someone doesn’t know something.</li>
               <li>Is willing and able to collaborate with others.</li>
               <li>Willing to admit when they're wrong, and aren't afraid to say "I don't know."</li>


### PR DESCRIPTION
With commit 74b5e520d945 ("Fix grammar: Are → is") that line was fixed,
but a later merge reintroduced the original line again, while keeping
the already fixed line.

Fixes: 5e121e8b1444 ("Merge branch 'master' into patch-1")