### PR TITLE
feat: Add trait on workplace behavior

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,6 +54,7 @@
               <li>Supports code in production, even if they did not write it.</li>
               <li>Can feel like an impostor at times.</li>
               <li>Makes sure discussions are always productive and everyone gets to have their say before the team makes a decision. Only disregards opinions by providing arguments.</li>
+              <li>Believes in constructive criticism in closed doors and compliments in public</li>
               <li>Creates community and shares knowledge.</li>
               <li>Never stops learning.</li>
               <li>Is willing to leave their comfort zone.</li>


### PR DESCRIPTION
Praise in public and criticize in private.

Some engineers (and managers) prey on other engineers that might not be so proficient in specific subjects or just decide to share their thoughts in a meeting room unpretentiously. They feed on this "window of opportunity" to be a cut-throating voice in a meeting room, rejoicing with the spotlight above their head and fomenting a toxic work environment where several other team mates feel ostracized or even intimidated.

The psychological safety is obliterated while they show their "Backbone" by disagreeing just for the sake of disagreeing in a pathetic exercise of personal marketing.

If this sort of execrable engineer is being promoted in your workplace, I have bad news for you.