### PR TITLE
Correct typo ("there of" to "thereof")

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@
           <li>May work from home, the office, a coffee shop, or where ever else best works for them.</li>
           <li>Doesn't hate on tools, processes, or languages that they'd rather not use, or that others are using.</li>
           <li>Is not defined by the computer they're using.</li>
-          <li>May decorate their laptop and workspace in any way they like, and is respectful of others' decor (or lack there of), too.</li>
+          <li>May decorate their laptop and workspace in any way they like, and is respectful of others' decor (or lack thereof), too.</li>
           <li>Isn't defined by myopic Tweetstorms by clueless VCs.</li>
       </ul>
     </section>


### PR DESCRIPTION
"Thereof" is the word to use in this situation. I tried to search online for an explanation or example, but it turned out to be impossible to find any discussion of this using a search engine, or at least it was for me.