### PR TITLE
A 1x engineer uses tabs and spaces consistently

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,7 @@
         <li>Willing to admit when they're wrong, and aren't afraid to say "I don't know."</li>
         <li>May or may not like writing documentation, but does it anyway for future maintainers.</li>
         <li>May or may not like writing tests, but tries to learn to do so if the team or project needs it.</li>
+        <li>May or may not like the team's coding conventions, but adheres to it.</li>
         <li>Thanks others for their time, effort, and energy.</li>
         <li>Can have colorful desktop backgrounds.</li>
         <li>Supports code in production, even if they did not write it.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,58 +37,58 @@
     <section class="nes-container with-title">
       <h2 class="title">A 1x Engineer...</h2>
       <ul class="lists">
-          <li>Searches Google, Duckduckgo, Bing, or wherever they like when they're not sure what's up.</li>
-          <li>Copy/pastes code snippets from Stack Overflow, Glitch, Codepen, or wherever they find answers.</li>
-          <li>Gives credit where credit is due.</li>
-          <li>Creates community and shares knowledge.</li>
-          <li>Spends time on things outside of engineering, like hobbies, friends, and family.</li>
-          <li>Has a schedule that allows them to maintain a healthy work-life balance, and respects others' time-boundaries, too.</li>
-          <li>Isn't measured by arbitrary contribution scores on any website, and doesn't judge others for theirs either.</li>
-          <li>Writes code that <span title="Don't worry about sending a PR for this, it's an intentional typo - you know, because we make bugs!">&emdash;</span> <em>gasp</em> &emdash; has bugs.</li>
-          <li>Writes code that others can read.</li>
-          <li>Reads the Docs.</li>
-          <li>Updates the Docs.</li>
-          <li>Doesn't need to be passionate about the code they write or the problems they solve, but may be.</li>
-          <li>Doesn't act surprised when someone doesn’t know something.</li>
-          <li>Is willing and able to collaborate with others.</li>
-          <li>Publicly celebrates others for their wins.</li>
-          <li>Ask questions before providing critical feedback.</li>
-          <li>Gives tough feedback privately.</li>
-          <li>Treats others how <em>they</em> would like to be treated.</li>
-          <li>Provides code reviews and feedback to their peers that are constructive, helpful, and presented tactfully, helping their peers to grow personally and professionally.</li>
-          <li>Expresses appreciation for code reviews and feedback from their peers that are constructive and helpful.</li>
-          <li>Sometimes feels hurt by critical feedback, but doesn't react destructively.</li>
-          <li>Sometimes takes short breaks to clear their head.</li>
-          <li>Sometimes is frustrated by their environment and needs to vent.</li>
-          <li>Makes mistakes from time to time, and finds growth in those mistakes.</li>
-          <li>Willing to admit when they're wrong, and aren't afraid to say "I don't know."</li>
-          <li>May or may not like writing documentation, but does it anyway for future maintainers.</li>
-          <li>May or may not like writing tests, but tries to learn to do so if the team or project needs it.</li>
-          <li>Thanks others for their time, effort, and energy.</li>
-          <li>Can have colorful desktop backgrounds.</li>
-          <li>Supports code in production, even if they did not write it.</li>
-          <li>Can feel like an imposter at times, and understands others may, too.</li>
-          <li>Believes that everyone in the room is equally as smart and capable as they are.</li>
-          <li>Will help level-up others, and asks for help when they need it.</li>
-          <li>Never stops learning, but can feel totally overwhelmed by the amount of learning there is to do.</li>
-          <li>Tries to keep discussions productive and lets others have their say before the team makes a decision.</li>
-          <li>Is willing to leave their comfort zone.</li>
-          <li>Contributes to the community in their own way when possible, and appreciates the ways that others contribute when they can.</li>
-          <li>Can be a slow coder.</li>
-          <li>Has productive and unproductive days.</li>
-          <li>Doesn't take themselves too seriously.</li>
-          <li>Says, "I've never heard of that," in lieu of nodding and pretending.</li>
-          <li>Is trustworthy.</li>
-          <li>Works to live, rather than living to work.</li>
-          <li>Sometimes loses their work.</li>
-          <li>Doesn't have to have the entire codebase memorized.</li>
-          <li>Respects and upholds community Codes of Conduct.</li>
-          <li>May work from home, the office, a coffee shop, or where ever else best works for them.</li>
-          <li>Doesn't hate on tools, processes, or languages that they'd rather not use, or that others are using.</li>
-          <li>Is not defined by the computer they're using.</li>
-          <li>May decorate their laptop and workspace in any way they like, and is respectful of others' decor (or lack thereof), too.</li>
-          <li>Isn't defined by myopic Tweetstorms by clueless VCs.</li>
-          <li>Doesn't ridicule entire professions within engineering, especially not when in a position of leadership.</li>
+        <li>Searches Google, Duckduckgo, Bing, or wherever they like when they're not sure what's up.</li>
+        <li>Copy/pastes code snippets from Stack Overflow, Glitch, Codepen, or wherever they find answers.</li>
+        <li>Gives credit where credit is due.</li>
+        <li>Creates community and shares knowledge.</li>
+        <li>Spends time on things outside of engineering, like hobbies, friends, and family.</li>
+        <li>Has a schedule that allows them to maintain a healthy work-life balance, and respects others' time-boundaries, too.</li>
+        <li>Isn't measured by arbitrary contribution scores on any website, and doesn't judge others for theirs either.</li>
+        <li>Writes code that <span title="Don't worry about sending a PR for this, it's an intentional typo - you know, because we make bugs!">&emdash;</span> <em>gasp</em> &emdash; has bugs.</li>
+        <li>Writes code that others can read.</li>
+        <li>Reads the Docs.</li>
+        <li>Updates the Docs.</li>
+        <li>Doesn't need to be passionate about the code they write or the problems they solve, but may be.</li>
+        <li>Doesn't act surprised when someone doesn’t know something.</li>
+        <li>Is willing and able to collaborate with others.</li>
+        <li>Publicly celebrates others for their wins.</li>
+        <li>Ask questions before providing critical feedback.</li>
+        <li>Gives tough feedback privately.</li>
+        <li>Treats others how <em>they</em> would like to be treated.</li>
+        <li>Provides code reviews and feedback to their peers that are constructive, helpful, and presented tactfully, helping their peers to grow personally and professionally.</li>
+        <li>Expresses appreciation for code reviews and feedback from their peers that are constructive and helpful.</li>
+        <li>Sometimes feels hurt by critical feedback, but doesn't react destructively.</li>
+        <li>Sometimes takes short breaks to clear their head.</li>
+        <li>Sometimes is frustrated by their environment and needs to vent.</li>
+        <li>Makes mistakes from time to time, and finds growth in those mistakes.</li>
+        <li>Willing to admit when they're wrong, and aren't afraid to say "I don't know."</li>
+        <li>May or may not like writing documentation, but does it anyway for future maintainers.</li>
+        <li>May or may not like writing tests, but tries to learn to do so if the team or project needs it.</li>
+        <li>Thanks others for their time, effort, and energy.</li>
+        <li>Can have colorful desktop backgrounds.</li>
+        <li>Supports code in production, even if they did not write it.</li>
+        <li>Can feel like an imposter at times, and understands others may, too.</li>
+        <li>Believes that everyone in the room is equally as smart and capable as they are.</li>
+        <li>Will help level-up others, and asks for help when they need it.</li>
+        <li>Never stops learning, but can feel totally overwhelmed by the amount of learning there is to do.</li>
+        <li>Tries to keep discussions productive and lets others have their say before the team makes a decision.</li>
+        <li>Is willing to leave their comfort zone.</li>
+        <li>Contributes to the community in their own way when possible, and appreciates the ways that others contribute when they can.</li>
+        <li>Can be a slow coder.</li>
+        <li>Has productive and unproductive days.</li>
+        <li>Doesn't take themselves too seriously.</li>
+        <li>Says, "I've never heard of that," in lieu of nodding and pretending.</li>
+        <li>Is trustworthy.</li>
+        <li>Works to live, rather than living to work.</li>
+        <li>Sometimes loses their work.</li>
+        <li>Doesn't have to have the entire codebase memorized.</li>
+        <li>Respects and upholds community Codes of Conduct.</li>
+        <li>May work from home, the office, a coffee shop, or where ever else best works for them.</li>
+        <li>Doesn't hate on tools, processes, or languages that they'd rather not use, or that others are using.</li>
+        <li>Is not defined by the computer they're using.</li>
+        <li>May decorate their laptop and workspace in any way they like, and is respectful of others' decor (or lack thereof), too.</li>
+        <li>Isn't defined by myopic Tweetstorms by clueless VCs.</li>
+        <li>Doesn't ridicule entire professions within engineering, especially not when in a position of leadership.</li>
       </ul>
     </section>
       <section>


### PR DESCRIPTION
I wanted to make the unordered list of traits an ordered one, and try to play around with priorities, as I think some traits are more important than others, and while it's fun to open with copy pasting snippets from Stackoverflow, some engineers - who are still real engineer, as per the "Doesn't riddicule entire professions within engineering[...]"  - don't even write code.

While moving lines around in the list, my editor was auto tabulating the lines to two spaces after pasting. At first I thought it's the IDEs fault, but then realized that the list uses different tabulation than the rest of the code, 4 spaces instead of 2. To keep it consistent, I suggest making it consistent now, to ease editing the file for everyone.