### PR TITLE
Add web archive link of 10x.engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ You can use the [styles options](https://shields.io/#styles) from the [Shields](
 
 - Brandon Olin, who [tweeted](https://twitter.com/devblackops/status/1149883098567331840) properties of a 1x engineer.
 - VC Dude, who [tweeted](https://twitter.com/skirani/status/1149302828420067328) about 10x engineers that got twitter super excited about revolting against the concept of 10x engineers.
-- 10x.engineer, for being awesome (sadly the site is gone)
+- 10x.engineer, for being awesome (sadly the site is gone). [Web archive link](https://web.archive.org/web/20190225233752/http://10x.engineer/)
 - [NES.CSS](https://nostalgic-css.github.io/NES.css/), for being really pretty


### PR DESCRIPTION
I've taken a link from 2019. I saw a snapshot in 2015 with only the regular nginx 404 page, and one in 2021 with the nginx 404 page and the text "10x engineers aren't real". I took this one from 2019, which has the "10x engineers aren't real", which I think makes the statement a bit more obvious.