### PR TITLE
Adjust Padding & Font Size to Fancy Styles

### DIFF
--- a/docs/styles/fancystyles.css
+++ b/docs/styles/fancystyles.css
@@ -14,7 +14,7 @@ body {
 }
 
 section {
-  padding: 3em 1.5em 0 1.5em;
+  padding: 3em 1.5em 2em 1.5em;
   min-width: 320px;
   max-width: 960px;
 }
@@ -25,6 +25,7 @@ section:last-of-type {
 
 .nes-container.with-title>.title {
   margin: -2.6rem 0 0 -7px;
+  font-size: 20px;
 }
 
 ul {


### PR DESCRIPTION
This will add some padding between the first section and font-size changes to the `<h2>` of the second section to help distinguish the different sections visually.

---

<details>
<summary>Screenshots</summary>

*Before*
![Screen Shot 2022-06-17 at 8 47 59 PM](https://user-images.githubusercontent.com/16884436/174415740-c4576eb1-e6d8-43cc-89a2-f9960500eb7c.png)


*After*
![Screen Shot 2022-06-17 at 8 45 15 PM](https://user-images.githubusercontent.com/16884436/174415721-a20d4b34-973a-4e5f-9fff-ce88dfe94ac3.png)

</details>